### PR TITLE
Corrections to issue #1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+v1.8.3
+------
+- Removed Bootstrap javascript request as not needed (21/07/2018)
+- Corrected gdpr checkbox display as it was disaplyed even if false is set (21/07/2018)
+- Removed `SubmitType` in FormType and replaced by adding button in template as it's not a "Best Practice" (Revert of v1.8.1) (21/07/2018)
+- Removed `Action` in controller method name as not requested anymore (21/07/2018)
+- Renamed variable `$contact` to `$contactForm` in Controller (21/07/2018)
+- Corrected meta in `layout.html.twig` (21/07/2018)
+
 v1.8.2.1
 --------
 - Removed required in composer.json (22/05/2018)

--- a/Controller/ContactFormController.php
+++ b/Controller/ContactFormController.php
@@ -27,7 +27,7 @@ class ContactFormController extends Controller
      *      name="contactform_display")
      * @Method({"GET", "HEAD", "POST"})
      */
-    public function displayAction(Request $request)
+    public function display(Request $request)
     {
         //Gets subject if passed by url parameter "s"
         $subject = filter_var($request->query->get('s'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
@@ -49,8 +49,8 @@ class ContactFormController extends Controller
         }
 
         //Defines contact
-        $contact = new ContactForm();
-        $contact
+        $contactForm = new ContactForm();
+        $contactForm
             ->setName($name)
             ->setEmail($userEmail)
             ->setSubject($subject)
@@ -58,11 +58,14 @@ class ContactFormController extends Controller
 
         //Dispatch event
         $dispatcher = $this->get('event_dispatcher');
-        $event = new ContactFormEvent($contact);
+        $event = new ContactFormEvent($contactForm);
         $dispatcher->dispatch(ContactFormEvent::CREATE_FORM, $event);
 
         //Defines form
-        $form = $this->createForm(ContactFormType::class, $contact, array('receiveCopy' => $event->getReceiveCopy()));
+        $form = $this->createForm(ContactFormType::class, $contactForm, array(
+            'receiveCopy' => $event->getReceiveCopy(),
+            'gdpr' => $this->getParameter('c975_l_contact_form.gdpr'),
+            ));
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/Form/ContactFormType.php
+++ b/Form/ContactFormType.php
@@ -13,7 +13,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -62,17 +61,14 @@ class ContactFormType extends AbstractType
                     ))
             ;
         }
-        $builder
-            ->add('gdpr', CheckboxType::class, array(
-                'label' => 'text.gdpr',
-                'required' => true,
-                'mapped' => false,
-                ))
-            ->add('submit', SubmitType::class, array(
-                'label' => 'label.send',
-                'attr' => array('class' => 'btn btn-block btn-lg btn-primary'),
-            ))
-        ;
+        if ($options['gdpr'] === true) {
+            $builder
+                ->add('gdpr', CheckboxType::class, array(
+                    'label' => 'text.gdpr',
+                    'required' => true,
+                    'mapped' => false,
+                    ));
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -83,6 +79,9 @@ class ContactFormType extends AbstractType
             'translation_domain' => 'contactForm',
         ));
 
-        $resolver->setRequired('receiveCopy');
+        $resolver
+            ->setRequired('receiveCopy')
+            ->setRequired('gdpr')
+        ;
     }
 }

--- a/Resources/views/forms/contact.html.twig
+++ b/Resources/views/forms/contact.html.twig
@@ -11,6 +11,12 @@
 {# Form #}
         {{ form_start(form) }}
             {{ form_widget(form) }}
+{# Submit#}
+            <div class="form-group">
+                <button type="submit" name="submit" title="{{ 'label.send'|trans }}" class="btn btn-lg btn-primary btn-block">
+                    {{ 'label.send'|trans }}
+                </button>
+            </div>
         {{ form_end(form) }}
 {# Mandatory field #}
         <p class="text-muted">

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -2,11 +2,12 @@
 
 {% spaceless %}
 <!DOCTYPE html>
+<html lang="{{ app.request.locale }}">
     <head>
         {% block head %}
             <meta charset="utf-8" />
-            <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-            <meta name="viewport" content="width=device-width initial-scale=1.0 maximum-scale=1.0 user-scalable=no" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="viewport" content="width=device-width initial-scale=1.0" />
             <meta name="format-detection" content="telephone=no" />
             <title>{{ 'label.contact'|trans }}</title>
             <base />
@@ -14,12 +15,6 @@
             {% block css %}
                 {# Uses c975L/IncludeLibraryBundle #}
                 {{ inc_lib('bootstrap', 'css', '3.*') }}
-                {{ inc_lib('fontawesome', 'css', '5.*') }}
-            {% endblock %}
-{# Javascript #}
-            {% block javascript %}
-                {# Uses c975L/IncludeLibraryBundle #}
-                {{ inc_lib('bootstrap', 'js', '3.*') }}
             {% endblock %}
         {% endblock %}
     </head>


### PR DESCRIPTION
- Removed Bootstrap javascript request as not needed (21/07/2018)
- Corrected gdpr checkbox display as it was disaplyed even if false is set (21/07/2018)
- Removed `SubmitType` in FormType and replaced by adding button in template as it's not a "Best Practice" (Revert of v1.8.1) (21/07/2018)
- Removed `Action` in controller method name as not requested anymore (21/07/2018)
- Renamed variable `$contact` to `$contactForm` in Controller (21/07/2018)
- Corrected meta in `layout.html.twig` (21/07/2018)